### PR TITLE
feat: add support for enumerating all certificates COMPASS-4105

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,50 @@
 # win-export-certificate-and-key
 
-Export a certificate and its corresponding private key from the Windows CA store.
+Access the Windows system certificate and key store.
 This module is a native addon. It will only successfully work on Windows.
 No prebuilt binaries are currently provided.
 
-This module returns a single certificate (and by default its private key)
+## API
+
+### `exportCertificateAndPrivateKey(opts?)`
+
+Export a certificate and its corresponding private key from the Windows CA store.
+
+Valid options are:
+
+- `subject`: Subject line of the certificate/key as a string.
+- `thumbprint`: Thumbprint of the certificate/key as a Uint8Array.
+  Either `subject` or `thumbprint` must be provided.
+- `store`: Optional Windows certificate store name. Default: `MY`.
+- `storeTypeList`: Optional array of Windows certificate store types
+  to try. Default: `['CERT_SYSTEM_STORE_LOCAL_MACHINE', 'CERT_SYSTEM_STORE_CURRENT_USER']`.
+- `requirePrivKey`: Boolean. If set, the
+  `REPORT_NO_PRIVATE_KEY | REPORT_NOT_ABLE_TO_EXPORT_PRIVATE_KEY` flags will
+  be passed to the wincrypt API.
+
+This function returns a single certificate (and by default its private key)
 combination as a .pfx file, along with a random passphrase that has been
 used for encrypting the file.
 It will throw an exception if no relevant certificate could be found.
 The certificate in question can be specified either through its subject line
 string or its thumbprint.
 
+### `exportSystemCertificates(opts?)`
+
+Export all system certificates (no private keys) matching the given
+options.
+
+Valid options are:
+
+- `store`: Optional Windows certificate store name. Default: `ROOT`.
+- `storeTypeList`: Optional array of Windows certificate store types
+  to try. Default: `['CERT_SYSTEM_STORE_LOCAL_MACHINE', 'CERT_SYSTEM_STORE_CURRENT_USER']`.
+
+This functions returns an array of PEM-formatted certificates.
+(Note that this can be a fairly slow operation.)
+
 ## Testing
 
-You need to import `testkeys\certificate.pfx` manually into your local 
+You need to import `testkeys\certificate.pfx` manually into your local
 CA store in order for the tests to pass. Make sure to import that certificate
 with the "exportable private key" option. The password for the file is `pass`.

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,17 @@
+declare type StoreType =
+  'CERT_SYSTEM_STORE_CURRENT_SERVICE' |
+  'CERT_SYSTEM_STORE_CURRENT_USER' |
+  'CERT_SYSTEM_STORE_CURRENT_USER_GROUP_POLICY' |
+  'CERT_SYSTEM_STORE_LOCAL_MACHINE' |
+  'CERT_SYSTEM_STORE_LOCAL_MACHINE_ENTERPRISE' |
+  'CERT_SYSTEM_STORE_LOCAL_MACHINE_GROUP_POLICY' |
+  'CERT_SYSTEM_STORE_SERVICES' |
+  'CERT_SYSTEM_STORE_USERS';
+
 declare function exportCertificateAndPrivateKey(input: {
   subject: string;
   store?: string;
+  storeTypeList?: Array<StoreType | number>;
   requirePrivKey?: boolean;
 } | {
   thumbprint: Uint8Array;

--- a/index.d.ts
+++ b/index.d.ts
@@ -8,14 +8,32 @@ declare type StoreType =
   'CERT_SYSTEM_STORE_SERVICES' |
   'CERT_SYSTEM_STORE_USERS';
 
-declare function exportCertificateAndPrivateKey(input: {
-  subject: string;
+declare interface StoreOptions {
   store?: string;
   storeTypeList?: Array<StoreType | number>;
+};
+
+declare type LookupOptions = StoreOptions & {
   requirePrivKey?: boolean;
+} & ({
+  subject: string;
+  thumbprint?: never;
 } | {
+  subject?: never;
   thumbprint: Uint8Array;
-  store?: string;
-  requirePrivKey?: boolean;
-}): { passphrase: string; pfx: Uint8Array; };
+});
+
+declare interface PfxResult {
+  passphrase: string;
+  pfx: Uint8Array;
+};
+
+declare function exportCertificateAndPrivateKey(input: LookupOptions): PfxResult;
+
+declare namespace exportCertificateAndPrivateKey {
+  function exportCertificateAndPrivateKey(input: LookupOptions): PfxResult;
+
+  function exportSystemCertificates(input: StoreOptions): string[];
+}
+
 export = exportCertificateAndPrivateKey;

--- a/index.js
+++ b/index.js
@@ -1,6 +1,50 @@
-const { exportCertificate, storeTypes } = require('bindings')('win_export_cert');
+const {
+  exportCertificateAndKey,
+  exportAllCertificates,
+  storeTypes
+} = require('bindings')('win_export_cert');
 const { randomBytes } = require('crypto');
+const forge = require('node-forge');
 const util = require('util');
+
+const DEFAULT_STORE_TYPE_LIST = ['CERT_SYSTEM_STORE_LOCAL_MACHINE', 'CERT_SYSTEM_STORE_CURRENT_USER'];
+
+function validateStoreTypeList(storeTypeList) {
+  storeTypeList = storeTypeList || DEFAULT_STORE_TYPE_LIST;
+  if (!Array.isArray(storeTypeList) ||
+      storeTypeList.length < 1 ||
+      !storeTypeList.every(st => typeof st === 'number' || Object.keys(storeTypes).includes(st))) {
+    throw new Error(`storeTypeList needs to be an array of valid store types`);
+  }
+  return storeTypeList.map(st => typeof st === 'number' ? st : storeTypes[st]);
+}
+
+function exportSystemCertificates(opts = {}) {
+  let {
+    store,
+    storeTypeList
+  } = opts;
+  storeTypeList = validateStoreTypeList(storeTypeList);
+
+  const result = new Set();
+  for (const storeType of storeTypeList) {
+    const certs = exportAllCertificates(store || 'ROOT', storeType);
+    for (const cert of certs) {
+      // Convert PKCS#12 (aka .pfx) to PEM
+      const asn1 = forge.asn1.fromDer(cert.toString('latin1'));
+      const pkcs12 = forge.pkcs12.pkcs12FromAsn1(asn1, '');
+      const certBags = pkcs12.getBags({ bagType: forge.pki.oids.certBag })[forge.pki.oids.certBag];
+      for (const bag of certBags) {
+        if (bag.cert) {
+          const pem = forge.pki.certificateToPem(bag.cert);
+          result.add(pem);
+        }
+      }
+    }
+  }
+
+  return [...result];
+}
 
 function exportCertificateAndPrivateKey(opts = {}) {
   let {
@@ -10,12 +54,8 @@ function exportCertificateAndPrivateKey(opts = {}) {
     storeTypeList,
     requirePrivKey
   } = opts;
-  storeTypeList = storeTypeList || ['CERT_SYSTEM_STORE_LOCAL_MACHINE', 'CERT_SYSTEM_STORE_CURRENT_USER'];
-  if (!Array.isArray(storeTypeList) ||
-      storeTypeList.length < 1 ||
-      !storeTypeList.every(st => typeof st === 'number' || Object.keys(storeTypes).includes(st))) {
-    throw new Error(`storeTypeList needs to be an array of valid store types`);
-  }
+  storeTypeList = validateStoreTypeList(storeTypeList);
+
   if (storeTypeList.length !== 1) {
     let err;
     for (const storeType of storeTypeList) {
@@ -42,13 +82,15 @@ function exportCertificateAndPrivateKey(opts = {}) {
   }
   requirePrivKey = requirePrivKey !== false;
   const passphrase = randomBytes(12).toString('hex');
-  const pfx = exportCertificate(
+  const pfx = exportCertificateAndKey(
     passphrase,
     store || 'MY',
-    typeof storeTypeList[0] === 'number' ? storeTypeList[0] : storeTypes[storeTypeList[0]],
+    storeTypeList[0],
     subject ? { subject } : { thumbprint },
     requirePrivKey);
   return { passphrase, pfx };
 }
 
 module.exports = exportCertificateAndPrivateKey;
+module.exports.exportCertificateAndPrivateKey = exportCertificateAndPrivateKey;
+module.exports.exportSystemCertificates = exportSystemCertificates;

--- a/index.js
+++ b/index.js
@@ -1,13 +1,33 @@
-const { exportCertificate } = require('bindings')('win_export_cert');
+const { exportCertificate, storeTypes } = require('bindings')('win_export_cert');
 const { randomBytes } = require('crypto');
 const util = require('util');
 
-module.exports = function exportCertificateAndPrivateKey({
-  subject,
-  thumbprint,
-  store,
-  requirePrivKey
-} = {}) {
+function exportCertificateAndPrivateKey(opts = {}) {
+  let {
+    subject,
+    thumbprint,
+    store,
+    storeTypeList,
+    requirePrivKey
+  } = opts;
+  storeTypeList = storeTypeList || ['CERT_SYSTEM_STORE_LOCAL_MACHINE', 'CERT_SYSTEM_STORE_CURRENT_USER'];
+  if (!Array.isArray(storeTypeList) ||
+      storeTypeList.length < 1 ||
+      !storeTypeList.every(st => typeof st === 'number' || Object.keys(storeTypes).includes(st))) {
+    throw new Error(`storeTypeList needs to be an array of valid store types`);
+  }
+  if (storeTypeList.length !== 1) {
+    let err;
+    for (const storeType of storeTypeList) {
+      try {
+        return exportCertificateAndPrivateKey({ ...opts, storeTypeList: [storeType] });
+      } catch(err_) {
+        err = err_;
+      }
+    }
+    throw err;
+  }
+
   if (!subject && !thumbprint) {
     throw new Error('Need to specify either `subject` or `thumbprint`');
   }
@@ -24,8 +44,11 @@ module.exports = function exportCertificateAndPrivateKey({
   const passphrase = randomBytes(12).toString('hex');
   const pfx = exportCertificate(
     passphrase,
-    store || 'MY', 
+    store || 'MY',
+    typeof storeTypeList[0] === 'number' ? storeTypeList[0] : storeTypes[storeTypeList[0]],
     subject ? { subject } : { thumbprint },
     requirePrivKey);
   return { passphrase, pfx };
 }
+
+module.exports = exportCertificateAndPrivateKey;

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
   "gypfile": true,
   "dependencies": {
     "bindings": "^1.5.0",
-    "node-addon-api": "^3.1.0"
+    "node-addon-api": "^3.1.0",
+    "node-forge": "^1.2.1"
   },
   "license": "Apache-2.0",
   "exports": {


### PR DESCRIPTION
(sibling PR to https://github.com/mongodb-js/macos-export-certificate-and-key/pull/1)

##### chore: use Node-API utf16 capability instead of Windows conversion

##### feat: allow querying multiple certificate store types [MONGOSH-1112](https://jira.mongodb.org/browse/MONGOSH-1112)

Fixes: https://github.com/mongodb-js/win-export-certificate-and-key/issues/1

##### chore: split out certificate store opening function

##### feat: add support for enumerating all certificates [COMPASS-4105](https://jira.mongodb.org/browse/COMPASS-4105)

This is conceptually very similar to the functionality
exposed by https://github.com/ukoloff/win-ca, but this
variant doesn't crash, leak memory, break when used by
multiple threads, etc.

Since this package already accesses the Windows system
CA stores, it feels like a natural place to add this here.