### PR TITLE
feat!: use OpenSSL instead of node-forge for DER-to-PEM conversion COMPASS-8073

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,10 +41,17 @@ Valid options are:
   to try. Default: `['CERT_SYSTEM_STORE_LOCAL_MACHINE', 'CERT_SYSTEM_STORE_CURRENT_USER']`.
 
 This functions returns an array of PEM-formatted certificates.
-(Note that this can be a fairly slow operation.)
 
 ## Testing
 
 You need to import `testkeys\certificate.pfx` manually into your local
 CA store in order for the tests to pass. Make sure to import that certificate
 with the "exportable private key" option. The password for the file is `pass`.
+
+## Compatibility
+
+Current versions of this package use OpenSSL to perform a format conversion
+from DER to PEM. This means that, unlike other Node-API addons, this addon
+has a stronger dependency on the ABI exposed by Node.js, and in particular
+may need to be updated once Node.js starts using OpenSSL 4.x (which is not
+planned at the time of writing).

--- a/index.js
+++ b/index.js
@@ -1,10 +1,10 @@
+'use strict';
 const {
   exportCertificateAndKey,
   exportAllCertificates,
   storeTypes
 } = require('bindings')('win_export_cert');
 const { randomBytes } = require('crypto');
-const forge = require('node-forge');
 const util = require('util');
 
 const DEFAULT_STORE_TYPE_LIST = ['CERT_SYSTEM_STORE_LOCAL_MACHINE', 'CERT_SYSTEM_STORE_CURRENT_USER'];
@@ -28,18 +28,8 @@ function exportSystemCertificates(opts = {}) {
 
   const result = new Set();
   for (const storeType of storeTypeList) {
-    const certs = exportAllCertificates(store || 'ROOT', storeType);
-    for (const cert of certs) {
-      // Convert PKCS#12 (aka .pfx) to PEM
-      const asn1 = forge.asn1.fromDer(cert.toString('latin1'));
-      const pkcs12 = forge.pkcs12.pkcs12FromAsn1(asn1, '');
-      const certBags = pkcs12.getBags({ bagType: forge.pki.oids.certBag })[forge.pki.oids.certBag];
-      for (const bag of certBags) {
-        if (bag.cert) {
-          const pem = forge.pki.certificateToPem(bag.cert);
-          result.add(pem);
-        }
-      }
+    for (const cert of exportAllCertificates(store || 'ROOT', storeType)) {
+      result.add(cert);
     }
   }
 

--- a/package.json
+++ b/package.json
@@ -14,8 +14,7 @@
   "gypfile": true,
   "dependencies": {
     "bindings": "^1.5.0",
-    "node-addon-api": "^3.1.0",
-    "node-forge": "^1.2.1"
+    "node-addon-api": "^3.1.0"
   },
   "license": "Apache-2.0",
   "exports": {

--- a/test.js
+++ b/test.js
@@ -1,3 +1,4 @@
+'use strict';
 const tls = require('tls');
 const fs = require('fs');
 const assert = require('assert');


### PR DESCRIPTION
This commit removes node-forge as a dependency and the conversion logic for X.509 certificates from DER to PEM format that we used it for, and replaces that logic with direct calls to OpenSSL functions (which are always available in Node.js).

The main downside of this approach is that it removes the ABI stability guarantees we get from Node-API and instead makes us dependent on the OpenSSL ABI as well. Currently, the functions used in this code are compatible with OpenSSL 1.1.x and 3.x, which should be good enough in the present and for at least a good number of years into the future.

The main upside of this approach is that it is significantly faster, and should enable applications that use this package to get the system certificate list to do so by default, rather than as an opt-in feature.